### PR TITLE
mos arch support

### DIFF
--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -3,7 +3,12 @@ mod wasm;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub use wasm::{Stdout, Stderr};
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[cfg(target_arch = "mos")]
+mod mos;
+#[cfg(target_arch = "mos")]
+pub use mos::{Stdout, Stderr};
+
+#[cfg(not(any(all(target_arch = "wasm32", target_os = "unknown"), target_arch="mos")))]
 mod std_c;
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+#[cfg(not(any(all(target_arch = "wasm32", target_os = "unknown"), target_arch="mos")))]
 pub use std_c::{Stdout, Stderr};

--- a/src/imp/mos.rs
+++ b/src/imp/mos.rs
@@ -23,9 +23,11 @@ impl Stderr {
 }
 
 extern "C" {
+    /// provided by https://github.com/llvm-mos/llvm-mos-sdk
     fn putchar(c: u8);
 }
 
+#[inline(always)]
 fn write(text: &str) {
     text.bytes().for_each(|b| unsafe { putchar(b) });
 }

--- a/src/imp/mos.rs
+++ b/src/imp/mos.rs
@@ -1,0 +1,49 @@
+///Stdout wrapper
+pub struct Stdout {
+}
+
+impl Stdout {
+    ///Creates new instance;
+    pub const fn new() -> Self {
+        Self {
+        }
+    }
+}
+
+///Stderr wrapper
+pub struct Stderr {
+}
+
+impl Stderr {
+    ///Creates new instance;
+    pub const fn new() -> Self {
+        Self {
+        }
+    }
+}
+
+extern "C" {
+    fn putchar(c: u8);
+}
+
+fn write(text: &str) {
+    text.bytes().for_each(|b| unsafe { putchar(b) });
+}
+
+impl ufmt::uWrite for Stdout {
+    type Error = ();
+
+    fn write_str(&mut self, text: &str) -> Result<(), Self::Error> {
+        write(text);
+        Ok(())
+    }
+}
+
+impl ufmt::uWrite for Stderr {
+    type Error = ();
+
+    fn write_str(&mut self, text: &str) -> Result<(), Self::Error> {
+        write(text);
+        Ok(())
+    }
+}


### PR DESCRIPTION
I just started using `ufmt` with `ufmt-stdio` on `mos-a800xl-none` (sic! - on 8-bit atari) and it works great, good job! Unfortunately libc there is very limited and I had to provide own backend using `putchar`. I was also thinking about exposing it under some feature, so it would be possible to use it on other targets without `libc` support.